### PR TITLE
Refine S3 URI schema and enforce distinct paths

### DIFF
--- a/app/event-schemas/complete-data-draft-schema.json
+++ b/app/event-schemas/complete-data-draft-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2012-12/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
     "s3Uri": {
       "type": "string",
@@ -8,6 +8,47 @@
     "s3UriDirectory": {
       "type": "string",
       "pattern": "^s3://[a-zA-Z0-9_-]*/[a-zA-Z0-9_./-]*/$"
+    },
+    "cacheUri": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/s3Uri"
+        },
+        {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": ".*/cache/.*"
+            }
+          ]
+        }
+      ]
+    },
+    "logsUri": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/s3Uri"
+        },
+        {
+          "type": "string",
+          "pattern": ".*/logs/.*"
+        }
+      ]
+    },
+    "outputUri": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/s3Uri"
+        },
+        {
+          "type": "string",
+          "pattern": ".*/analysis/.*"
+        },
+        {
+          "type": "string",
+          "pattern": ".*/output/.*"
+        }
+      ]
     },
     "genomes": {
       "type": "object",
@@ -195,13 +236,13 @@
           "type": "string"
         },
         "outputUri": {
-          "$ref": "#/$defs/s3UriDirectory"
+          "$ref": "#/$defs/outputUri"
         },
         "logsUri": {
-          "$ref": "#/$defs/s3UriDirectory"
+          "$ref": "#/$defs/logsUri"
         },
         "cacheUri": {
-          "$ref": "#/$defs/s3UriDirectory"
+          "$ref": "#/$defs/cacheUri"
         }
       },
       "required": ["projectId", "pipelineId", "outputUri", "logsUri", "cacheUri"],

--- a/app/event-schemas/complete-data-draft-schema.json
+++ b/app/event-schemas/complete-data-draft-schema.json
@@ -12,7 +12,7 @@
     "cacheUri": {
       "allOf": [
         {
-          "$ref": "#/$defs/s3Uri"
+          "$ref": "#/$defs/s3UriDirectory"
         },
         {
           "oneOf": [
@@ -27,7 +27,7 @@
     "logsUri": {
       "allOf": [
         {
-          "$ref": "#/$defs/s3Uri"
+          "$ref": "#/$defs/s3UriDirectory"
         },
         {
           "type": "string",
@@ -38,7 +38,7 @@
     "outputUri": {
       "allOf": [
         {
-          "$ref": "#/$defs/s3Uri"
+          "$ref": "#/$defs/s3UriDirectory"
         },
         {
           "oneOf": [

--- a/app/event-schemas/complete-data-draft-schema.json
+++ b/app/event-schemas/complete-data-draft-schema.json
@@ -41,12 +41,16 @@
           "$ref": "#/$defs/s3Uri"
         },
         {
-          "type": "string",
-          "pattern": ".*/analysis/.*"
-        },
-        {
-          "type": "string",
-          "pattern": ".*/output/.*"
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": ".*/analysis/.*"
+            },
+            {
+              "type": "string",
+              "pattern": ".*/output/.*"
+            }
+          ]
         }
       ]
     },

--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -72,6 +72,12 @@ def validate_engine_parameters(
     if not cache_uri.startswith(project_prefix):
         return False, f"cacheUri '{cache_uri}' is not in the project context '{project_prefix}'"
 
+    # Ensure that the output uri, logs uri and cache uri aren't all the same
+    if not (
+            len(list({output_uri, logs_uri, cache_uri})) == len(list([output_uri, logs_uri, cache_uri]))
+    ):
+        return False, f"output uri, logs uri and cache uri must all be distinct"
+
     # Confirm the pipeline is in the project
     try:
         _ = get_project_pipeline_obj(

--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -72,7 +72,7 @@ def validate_engine_parameters(
     if not cache_uri.startswith(project_prefix):
         return False, f"cacheUri '{cache_uri}' is not in the project context '{project_prefix}'"
 
-    # Ensure that the output uri, logs uri and cache uri aren't all the same
+    # Ensure that the output uri, logs uri and cache uri are all distinct
     for (uri_1, uri_2) in permutations([output_uri, logs_uri, cache_uri], 2):
         if uri_1 == uri_2:
             return False, f"output uri, logs uri and cache uri must all be distinct"

--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -14,8 +14,8 @@ all start with the project prefix.
 Log any failures to the OrcaUI
 
 """
-
 # Imports
+from itertools import permutations
 from typing import Dict, Tuple
 import logging
 from os import environ
@@ -73,10 +73,9 @@ def validate_engine_parameters(
         return False, f"cacheUri '{cache_uri}' is not in the project context '{project_prefix}'"
 
     # Ensure that the output uri, logs uri and cache uri aren't all the same
-    if not (
-            len(list({output_uri, logs_uri, cache_uri})) == len(list([output_uri, logs_uri, cache_uri]))
-    ):
-        return False, f"output uri, logs uri and cache uri must all be distinct"
+    for (uri_1, uri_2) in permutations([output_uri, logs_uri, cache_uri], 2):
+        if uri_1 == uri_2:
+            return False, f"output uri, logs uri and cache uri must all be distinct"
 
     # Confirm the pipeline is in the project
     try:


### PR DESCRIPTION
-----
app/event-schemas/complete-data-draft-schema.json:
* Upgrade JSON schema draft version to 2020-12.
* Introduce dedicated S3 URI types (cache, logs, output) with specific path patterns.
* Update workflow properties to use these new, refined URI definitions.

-----
app/lambdas/post_schema_validation_py/post_schema_validation.py:
* Add runtime validation to ensure output, logs, and cache URIs are distinct.