### PR TITLE
Adds SSM parameter for default event schema version

### DIFF
--- a/infrastructure/stage/event-schemas/index.ts
+++ b/infrastructure/stage/event-schemas/index.ts
@@ -1,6 +1,7 @@
 import * as schemas from 'aws-cdk-lib/aws-eventschemas';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import {
+  DEFAULT_PAYLOAD_VERSION,
   EVENT_SCHEMAS_DIR,
   SCHEMA_REGISTRY_NAME,
   SSM_SCHEMA_ROOT,

--- a/infrastructure/stage/event-schemas/index.ts
+++ b/infrastructure/stage/event-schemas/index.ts
@@ -47,8 +47,6 @@ export function buildSchemas(scope: Construct) {
           schemaName: schemaName,
           payloadVersion: payloadVersion,
         });
-        // And also a latest ssm parameter for the schema
-        // Likely the one most commonly used
         new ssm.StringParameter(scope, `${schemaName}-${payloadVersion}--ssm`, {
           parameterName: path.join(
             SSM_SCHEMA_ROOT,
@@ -61,6 +59,21 @@ export function buildSchemas(scope: Construct) {
             schemaVersion: schemaObj.attrSchemaVersion,
           }),
         });
+        // And also an ssm parameter for the default used schema
+        if (payloadVersion === DEFAULT_PAYLOAD_VERSION){
+            new ssm.StringParameter(scope, `${schemaName}-default--ssm`, {
+              parameterName: path.join(
+                SSM_SCHEMA_ROOT,
+                camelCaseToKebabCase(schemaName),
+                'default'
+              ),
+              stringValue: JSON.stringify({
+                registryName: schemaObj.registryName,
+                schemaName: schemaObj.attrSchemaName,
+                schemaVersion: schemaObj.attrSchemaVersion,
+              }),
+            });
+        }
       }
     }
   }

--- a/infrastructure/stage/event-schemas/index.ts
+++ b/infrastructure/stage/event-schemas/index.ts
@@ -60,19 +60,15 @@ export function buildSchemas(scope: Construct) {
           }),
         });
         // And also an ssm parameter for the default used schema
-        if (payloadVersion === DEFAULT_PAYLOAD_VERSION){
-            new ssm.StringParameter(scope, `${schemaName}-default--ssm`, {
-              parameterName: path.join(
-                SSM_SCHEMA_ROOT,
-                camelCaseToKebabCase(schemaName),
-                'default'
-              ),
-              stringValue: JSON.stringify({
-                registryName: schemaObj.registryName,
-                schemaName: schemaObj.attrSchemaName,
-                schemaVersion: schemaObj.attrSchemaVersion,
-              }),
-            });
+        if (payloadVersion === DEFAULT_PAYLOAD_VERSION) {
+          new ssm.StringParameter(scope, `${schemaName}-default--ssm`, {
+            parameterName: path.join(SSM_SCHEMA_ROOT, camelCaseToKebabCase(schemaName), 'default'),
+            stringValue: JSON.stringify({
+              registryName: schemaObj.registryName,
+              schemaName: schemaObj.attrSchemaName,
+              schemaVersion: schemaObj.attrSchemaVersion,
+            }),
+          });
         }
       }
     }


### PR DESCRIPTION
Introduces a new SSM parameter for event schemas:
- Provides a stable reference to the `DEFAULT_PAYLOAD_VERSION` of a schema, simplifying access for consumers.
- Allows event schema consumers to always retrieve the currently designated default schema without needing to track specific version numbers.
- Defines `DEFAULT_PAYLOAD_VERSION` as a constant to identify the default schema during deployment.