### PR TITLE
Remove null values from WRU event inputs

### DIFF
--- a/app/lambdas/generate_wru_event_object_with_merged_data_py/generate_wru_event_object_with_merged_data.py
+++ b/app/lambdas/generate_wru_event_object_with_merged_data_py/generate_wru_event_object_with_merged_data.py
@@ -73,6 +73,12 @@ def handler(event, context):
     new_data_object["inputs"]["tumorDnaBamUri"] = dragen_tumor_bam_uri
     new_data_object["inputs"]["normalDnaBamUri"] = dragen_normal_bam_uri
 
+    # Drop null keys in inputs
+    new_data_object["inputs"] = dict(filter(
+        lambda kv_iter_: kv_iter_[1] is not None,
+        new_data_object["inputs"].copy().items()
+    ))
+
     # Update the inputs with the dragen draft payload data
     oncoanalyser_draft_workflow_update["payload"] = {
         "version": payload['version'],

--- a/infrastructure/stage/interfaces.ts
+++ b/infrastructure/stage/interfaces.ts
@@ -13,7 +13,6 @@ import { StageName } from '@orcabus/platform-cdk-constructs/shared-config/accoun
 
 export interface StatefulApplicationStackConfig {
   // Values
-  // Detail
   ssmParameterValues: SsmParameterValues;
 
   // Keys


### PR DESCRIPTION
This change introduces a filter to remove null (None) values from the "inputs" dictionary within the WRU event object generation process in a Python lambda. Additionally, a minor documentation comment is removed from an infrastructure interface definition. 

**Changes**
**app/lambdas/generate_wru_event_object_with_merged_data_py/generate_wru_event_object_with_merged_data.py**: Modified the handler function to filter out key-value pairs where the value is None from the new_data_object["inputs"] dictionary, ensuring only non-null inputs are included in the generated event.
**infrastructure/stage/interfaces.ts**: Removed a non-functional comment line 
// Detail from the StatefulApplicationStackConfig interface definition.

**Impact**

**Behavioral changes**: The generated WRU event object will no longer contain null values within its inputs field, standardizing the output structure by omitting unpopulated optional fields.
**Dependencies affected**: Downstream systems consuming the WRU event object might observe cleaner input data without explicit null fields, potentially simplifying their parsing logic.
**Breaking changes, if any**: No breaking changes are anticipated; rather, the output data becomes more consistent.
**Performance implications, if apparent**: Minimal performance impact due to dictionary copying and filtering operations for typical data volumes.