### PR TITLE
Adopts GitStack for application stacks

### DIFF
--- a/infrastructure/stage/stateful-application-stack.ts
+++ b/infrastructure/stage/stateful-application-stack.ts
@@ -3,10 +3,11 @@ import { Construct } from 'constructs';
 import { StatefulApplicationStackConfig } from './interfaces';
 import { buildSsmParameters } from './ssm';
 import { buildSchemas } from './event-schemas';
+import { GitStack } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';
 
 export type StatefulApplicationStackProps = cdk.StackProps & StatefulApplicationStackConfig;
 
-export class StatefulApplicationStack extends cdk.Stack {
+export class StatefulApplicationStack extends GitStack {
   constructor(scope: Construct, id: string, props: StatefulApplicationStackProps) {
     super(scope, id, props);
 

--- a/infrastructure/stage/stateless-application-stack.ts
+++ b/infrastructure/stage/stateless-application-stack.ts
@@ -7,10 +7,11 @@ import { buildAllStepFunctions } from './step-functions';
 import { buildAllEventRules } from './event-rules';
 import { buildAllEventBridgeTargets } from './event-targets';
 import { StageName } from '@orcabus/platform-cdk-constructs/shared-config/accounts';
+import { GitStack } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';
 
 export type StatelessApplicationStackProps = cdk.StackProps & StatelessApplicationStackConfig;
 
-export class StatelessApplicationStack extends cdk.Stack {
+export class StatelessApplicationStack extends GitStack {
   public readonly stageName: StageName;
 
   constructor(scope: Construct, id: string, props: StatelessApplicationStackProps) {


### PR DESCRIPTION
Migrates both stateful and stateless application stacks to extend `GitStack` instead of `cdk.Stack`. This change standardizes the base class for deployment stacks, integrating with the platform's deployment pipeline and leveraging `GitStack`'s specialized capabilities.