### PR TITLE
Force downstream draft list of portal run ids to be in list format

### DIFF
--- a/app/step-functions-templates/glue_succeeded_events_to_draft_update_sfn_template.asl.json
+++ b/app/step-functions-templates/glue_succeeded_events_to_draft_update_sfn_template.asl.json
@@ -74,7 +74,7 @@
       ],
       "Next": "Did we get a oncoanalyser portal run id",
       "Assign": {
-        "draftPortalRunIdList": "{% $states.result.Payload.workflowRunList ? $states.result.Payload.workflowRunList.(portalRunId) : null %}"
+        "draftPortalRunIdList": "{% $states.result.Payload.workflowRunList ? [ $states.result.Payload.workflowRunList.(portalRunId) ] : null %}"
       }
     },
     "Did we get a oncoanalyser portal run id": {


### PR DESCRIPTION
Jsonata will convert any translation of a singular list into a string, use the `[ ]` wrapper to force into a list format