### PR TITLE
Feature/handle one of json schema complexities

### DIFF
--- a/app/lambdas/add_populate_draft_comment_py/add_populate_draft_comment.py
+++ b/app/lambdas/add_populate_draft_comment_py/add_populate_draft_comment.py
@@ -11,7 +11,7 @@ Provides commentary on state transitions during draft data population:
 
 # Standard imports
 from os import environ
-from typing import Dict, Any
+from typing import Dict, Any, List, Union
 
 # Layer imports
 from orcabus_api_tools.workflow import add_comment_to_workflow_run
@@ -30,6 +30,51 @@ COMMENT_TEMPLATES = {
     "updating_inputs": "Updating inputs — this may take time to complete if awaiting upstream data or unarchiving.",
     "no_change_missing_fields": "Draft payload has not changed since last population attempt. The following required schema fields are still missing or incomplete:\n{missing_fields_list}\n\nTo resolve this, either:\nA) Wait for upstream processes to complete (FASTQ data availability, unarchiving)\nB) Manually provide the missing attributes via a WorkflowRunUpdate event\n\nFor details on upstream dependencies and manual submission, see: {repo_url}",
 }
+
+
+def write_missing_fields_list(
+        missing_fields: List[Union[Dict[str, Any], str]],
+        nest_level: int = 0,
+) -> List[str]:
+    """
+    Generate missing fields list
+    :param missing_fields:
+    :return:
+    """
+    missing_fields_str_list = []
+    for field in missing_fields:
+        if isinstance(field, str):
+            missing_fields_str_list.append(
+                (" " * nest_level) + f"- {field}"
+            )
+        if isinstance(field, dict):
+            for field_key, field_value in field.items():
+                if field_key == "oneOf":
+                    for one_of_idx, one_of_list in enumerate(field_value):
+                        missing_fields_str_list.append(
+                            (" " * nest_level) + "All of:"
+                        )
+                        for one_of_item_path, one_of_item_keys in one_of_list.items():
+                            if isinstance(one_of_item_keys, str):
+                                missing_fields_str_list.append(
+                                    (" " * (nest_level + 1)) + f"- {one_of_item_keys}"
+                                )
+                            elif isinstance(one_of_item_keys, list):
+                                for item in one_of_item_keys:
+                                    missing_fields_str_list.append(
+                                        (" " * (nest_level + 1)) + f"- {item}"
+                                    )
+                            elif isinstance(one_of_item_keys, dict):
+                                missing_fields_str_list.extend(
+                                    write_missing_fields_list(
+                                        [one_of_item_keys],
+                                        nest_level + 1
+                                    )
+                                )
+                        if not one_of_idx == (len(field_value) - 1):
+                            missing_fields_str_list.append((" " * (nest_level)) + f"--- OR ---")
+
+    return missing_fields_str_list  # prefix each with \n-
 
 
 def handler(event: Dict[str, Any], context) -> Dict[str, bool]:
@@ -63,8 +108,9 @@ def handler(event: Dict[str, Any], context) -> Dict[str, bool]:
 
     # Handle the no_change_missing_fields template specially
     if comment_type == "no_change_missing_fields" and missing_fields:
-        missing_fields_list = "\n- ".join([""] + missing_fields)  # prefix each with \n-
-        body = body.format(missing_fields_list=missing_fields_list, repo_url=repo_url)
+        missing_fields_list = write_missing_fields_list(missing_fields)
+        # missing_fields_list = "\n- ".join([""] + missing_fields)  # prefix each with \n-
+        body = body.format(missing_fields_list="\n".join([""] + missing_fields_list), repo_url=repo_url)
     elif comment_type == "no_change_missing_fields":
         body = body.format(missing_fields_list="\n- (none detected)", repo_url=repo_url)
 

--- a/app/lambdas/add_populate_draft_comment_py/add_populate_draft_comment.py
+++ b/app/lambdas/add_populate_draft_comment_py/add_populate_draft_comment.py
@@ -51,10 +51,10 @@ def write_missing_fields_list(
             for field_key, field_value in field.items():
                 if field_key == "oneOf":
                     for one_of_idx, one_of_list in enumerate(field_value):
-                        missing_fields_str_list.append(
-                            (" " * nest_level) + "All of:"
-                        )
                         for one_of_item_path, one_of_item_keys in one_of_list.items():
+                            missing_fields_str_list.append(
+                                (" " * nest_level) + f"All of ({one_of_item_path}):"
+                            )
                             if isinstance(one_of_item_keys, str):
                                 missing_fields_str_list.append(
                                     (" " * (nest_level + 1)) + f"- {one_of_item_keys}"

--- a/app/lambdas/get_missing_schema_fields_py/get_missing_schema_fields.py
+++ b/app/lambdas/get_missing_schema_fields_py/get_missing_schema_fields.py
@@ -93,14 +93,11 @@ def get_one_of_missing_field_summaries(
         )
 
         if option_missing_fields:
-            for field in option_missing_fields:
-                missing_field_option_list.append(field)
-
-        missing_field_options.append(
-            {
-                f"{path}: {option["$ref"].rsplit("/")[-1]} path": missing_field_option_list
-            }
-        )
+            missing_field_options.append(
+                {
+                    f'{path}: {option["$ref"].rsplit("/")[-1]} path': option_missing_fields
+                }
+            )
 
     return missing_field_options
 

--- a/app/lambdas/get_missing_schema_fields_py/get_missing_schema_fields.py
+++ b/app/lambdas/get_missing_schema_fields_py/get_missing_schema_fields.py
@@ -158,13 +158,13 @@ def handler(event, context):
                 missing_fields.append(f"{path} ({error.message[:50]})")
 
     # Reduce string duplicates
-    missing_fields_str = list(set(list(filter(
+    missing_fields_str = sorted(set(list(filter(
         lambda missing_field_iter: isinstance(missing_field_iter, str),
         missing_fields
     ))))
 
     missing_fields = missing_fields_str + list(filter(
-        lambda missing_field_iter: isinstance(missing_field_iter, Dict),
+        lambda missing_field_iter: isinstance(missing_field_iter, dict),
         missing_fields
     ))
 

--- a/app/lambdas/get_missing_schema_fields_py/get_missing_schema_fields.py
+++ b/app/lambdas/get_missing_schema_fields_py/get_missing_schema_fields.py
@@ -70,7 +70,7 @@ def get_one_of_missing_field_summaries(
         schema: dict,
         error: jsonschema.ValidationError,
         path: str
-) -> list[str]:
+) -> list[dict[str, list[str]]]:
     """
     Summarise oneOf validation failures without exposing every nested conditional.
 
@@ -101,13 +101,6 @@ def get_one_of_missing_field_summaries(
                 f"{path}: {option["$ref"].rsplit("/")[-1]} path": missing_field_option_list
             }
         )
-
-    missing_field_options_counted = []
-    for idx, one_of_object in enumerate(missing_field_options, start=1):
-        for required_arg in one_of_object:
-            missing_field_options_counted.append(
-                f"Opt. {idx}: {required_arg}"
-            )
 
     return missing_field_options
 

--- a/app/lambdas/get_missing_schema_fields_py/get_missing_schema_fields.py
+++ b/app/lambdas/get_missing_schema_fields_py/get_missing_schema_fields.py
@@ -4,12 +4,14 @@
 Given a payload data object, validate it against the schema and return the list of missing/invalid fields.
 """
 
+# Standard imports
 import boto3
 import json
 import typing
 import jsonschema
-from os import environ
 from pathlib import Path
+from os import environ
+from typing import List, Dict, Union, Any
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_schemas import SchemasClient
@@ -30,6 +32,84 @@ def get_schema_from_registry(registry_name: str, schema_name: str) -> str:
     schemas_client: "SchemasClient" = boto3.client("schemas")
     response = schemas_client.describe_schema(RegistryName=registry_name, SchemaName=schema_name)
     return response["Content"]
+
+
+def resolve_schema_ref(schema: dict, ref: str) -> dict:
+    """
+    Resolve a local JSON schema $ref like '#/$defs/FastqInputs'.
+    """
+    if not ref.startswith("#/"):
+        return {}
+
+    resolved = schema
+    for ref_part in ref.lstrip("#/").split("/"):
+        resolved = resolved.get(ref_part, {})
+
+    return resolved
+
+
+def get_missing_required_fields_for_schema_option(
+        schema_option: dict,
+        instance: dict,
+        path: str
+) -> list[str]:
+    """
+    Given a resolved oneOf schema option, return the missing required field paths.
+    """
+    missing_fields = []
+
+    for required_field in schema_option.get("required", []):
+        if not isinstance(instance, dict) or required_field not in instance:
+            field_path = f"{path}.{required_field}" if path else required_field
+            missing_fields.append(field_path)
+
+    return missing_fields
+
+
+def get_one_of_missing_field_summaries(
+        schema: dict,
+        error: jsonschema.ValidationError,
+        path: str
+) -> list[str]:
+    """
+    Summarise oneOf validation failures without exposing every nested conditional.
+
+    Assumes oneOf options are $ref objects. For each referenced option, collect the
+    missing required fields. Then pair equivalent missing fields into concise
+    'either X or Y' messages.
+    """
+    missing_field_options = []
+
+    for idx, option in enumerate(error.validator_value, start=1):
+        missing_field_option_list = []
+        if not (isinstance(option, dict) and "$ref" in option):
+            continue
+
+        resolved_option = resolve_schema_ref(schema, option["$ref"])
+        option_missing_fields = get_missing_required_fields_for_schema_option(
+            resolved_option,
+            error.instance,
+            path
+        )
+
+        if option_missing_fields:
+            for field in option_missing_fields:
+                missing_field_option_list.append(field)
+
+        missing_field_options.append(
+            {
+                f"{path}: {option["$ref"].rsplit("/")[-1]} path": missing_field_option_list
+            }
+        )
+
+    missing_field_options_counted = []
+    for idx, one_of_object in enumerate(missing_field_options, start=1):
+        for required_arg in one_of_object:
+            missing_field_options_counted.append(
+                f"Opt. {idx}: {required_arg}"
+            )
+
+    return missing_field_options
 
 
 def handler(event, context):
@@ -63,7 +143,7 @@ def handler(event, context):
     errors = list(validator.iter_errors(data))
 
     # Extract missing field paths
-    missing_fields = []
+    missing_fields: List[Union[Dict[str, Any], str]] = []
     for error in errors:
         path = ".".join(str(p) for p in error.absolute_path) if error.absolute_path else ""
         if error.validator == "required":
@@ -72,9 +152,30 @@ def handler(event, context):
                 if missing_prop not in error.instance:
                     field_path = f"{path}.{missing_prop}" if path else missing_prop
                     missing_fields.append(field_path)
+        elif error.validator == "oneOf":
+            missing_fields.append(
+                {
+                    "oneOf": get_one_of_missing_field_summaries(
+                        schema,
+                        error,
+                        path
+                    )
+                }
+            )
         else:
             # For other errors (type, pattern, etc.)
             if path:
                 missing_fields.append(f"{path} ({error.message[:50]})")
+
+    # Reduce string duplicates
+    missing_fields_str = list(set(list(filter(
+        lambda missing_field_iter: isinstance(missing_field_iter, str),
+        missing_fields
+    ))))
+
+    missing_fields = missing_fields_str + list(filter(
+        lambda missing_field_iter: isinstance(missing_field_iter, Dict),
+        missing_fields
+    ))
 
     return {"missingFields": missing_fields}


### PR DESCRIPTION
There are some schemas that error out because the json object does not satisfy a 'oneOf'.

Update the jsonschema validation summariser so that errors of missing fields are better described